### PR TITLE
Install basic foundations for S2ZE porting guide

### DIFF
--- a/docs/CommunityGuides/_category_.json
+++ b/docs/CommunityGuides/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Community Guides",
+  "position": 6,
+  "collapsed": true
+}

--- a/docs/CommunityGuides/index.mdx
+++ b/docs/CommunityGuides/index.mdx
@@ -1,0 +1,10 @@
+---
+description: Guides made by various Source 2 communities.
+title: Community Guides
+---
+
+Guides made by various Source 2 communities, promoting mapping guidelines and sharing useful information amongst mappers.
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/_category_.json
+++ b/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Exploiting Source 2",
+  "position": 2,
+  "collapsed": true
+}

--- a/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/advanced.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/advanced.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 6
+---
+
+# Advanced Techniques
+
+ch 2.10

--- a/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/comparisons.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/comparisons.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 7
+---
+
+# Comparisons in Our Ports
+
+ch 3

--- a/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/index.mdx
+++ b/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/index.mdx
@@ -1,0 +1,12 @@
+---
+description: Utilizing S2 to its maximum.
+title: Exploiting Source 2
+---
+
+The Source 2 engine has introduced various additions and improvements that were previously unimaginable in the previous Source 1 installments. This section aims to highlight the key entities and techniques solely exclusing in the S2 engine.
+
+Although strictly optional, implementing the many features of the S2 engine will bring a drastic improevment in the quality of the port.
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/lightning.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/lightning.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 3
+---
+
+# Lightning
+
+ch 2.5

--- a/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/loading.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/loading.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 2
+---
+
+# Loading Screen
+
+ch 2.3

--- a/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/post_processing.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/post_processing.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 4
+---
+
+# Post Processing
+
+ch 2.6

--- a/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/s2_ents.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/s2_ents.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 1
+---
+
+# Source 2 Entities
+
+ch 2.2

--- a/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/texture.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/ExploitingS2/texture.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 5
+---
+
+# Textures
+
+ch 2.8

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/_category_.json
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Mandatory Works",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/env_fix.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/env_fix.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 5
+---
+
+# Fixing Environments
+
+ch 1.6, ch 1.5, ch 1.14

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/import_tool.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/import_tool.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 2
+---
+
+# Import Tool
+
+ch 1.2

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/index.mdx
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/index.mdx
@@ -1,0 +1,16 @@
+---
+description: Crucial works to make the map operational.
+title: Mandatory Works
+---
+
+The improvement from Source 1 to Source 2 has brought many changes to how a map is structured. Even with the assistance of Valve's Import Tool, considerable work is required to make the map fully operational and of the same quality as CS:GO.
+
+:::info
+It is important that the information within this section be implemented in the port. This ensures the port is stable on a live server gameplay, and reduces the likelihood of it being rejected from servers due to quality issues.
+
+Remember, the first impression is important!
+:::
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/item.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/item.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 10
+---
+
+# Items
+
+ch 1.13

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/levels.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/levels.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 8
+---
+
+# Levels
+
+ch 1.16

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/material_model.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/material_model.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 6
+---
+
+# Materials & Models
+
+ch -1, ch 1.8

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/minimap.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/minimap.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 12
+---
+
+# Minimap
+
+ch 1.11

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/particle.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/particle.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 9
+---
+
+# Particles
+
+ch 1.12

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/qc.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/qc.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 14
+---
+
+# Quality Control
+
+ch 1.17, ch 2.9 (+ ch 2.4), ch 2.7

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/s1_ents.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/s1_ents.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 3
+---
+
+# S1 Entities
+
+ch 1.3

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/s2_quirks.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/s2_quirks.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 4
+---
+
+# Managing S2 Weirdness
+
+ch 1.4

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/sound.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/sound.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 11
+---
+
+# Sounds
+
+ch 1.7

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/steam_workshop.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/steam_workshop.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 15
+---
+
+# Uploading to Steam Workshop
+
+ch 1.18

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/stripper.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/stripper.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 1
+---
+
+# Stripper Configs
+
+ch 1.1

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/vis.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/vis.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 7
+---
+
+# VIS
+
+ch 1.10

--- a/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/zr.md
+++ b/docs/CommunityGuides/s2ze/PortingGuide/MandatoryWorks/zr.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 13
+---
+
+# Applying Zombie:Reborn (ZR)
+
+ch 1.15

--- a/docs/CommunityGuides/s2ze/PortingGuide/_category_.json
+++ b/docs/CommunityGuides/s2ze/PortingGuide/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Porting Guide",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/CommunityGuides/s2ze/PortingGuide/index.mdx
+++ b/docs/CommunityGuides/s2ze/PortingGuide/index.mdx
@@ -1,0 +1,22 @@
+---
+description: Porting guide made for Zombie Escape maps
+title: Porting Guide
+---
+
+## Introduction
+
+This porting guide provides useful information when porting a Zombie Escape map from CS:GO to CS2. It covers procedures to follow when porting the map, suggests workarounds for potential pitfalls, provides guidance on implementing new Source 2 features, and more.
+
+Although this guide was written primarily for the Zombie Escape gamemode, it is versatile enough to be used and implemented for other gamemodes. Similarly, the guide can be useful for a general porting process from Source 1 to Source 2.
+
+The wiki is set up in an order of recommended steps to take when porting a map from scratch, but it can be freely used as a wiki.
+
+:::note[Legacy]
+Our previous implementation of the guide can be found [here](https://docs.google.com/document/d/1buKzjP-2com9GcXVxCfyRBi6sDiKmzMoVy9RNbYQqIo).
+:::
+
+## Sections
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/CommunityGuides/s2ze/_category_.json
+++ b/docs/CommunityGuides/s2ze/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Source 2 Zombie Escape (S2ZE)",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/CommunityGuides/s2ze/index.mdx
+++ b/docs/CommunityGuides/s2ze/index.mdx
@@ -1,0 +1,17 @@
+---
+description: Guides made by various Source 2 communities.
+title: Source 2 Zombie Escape (S2ZE)
+---
+
+Various guides created by the members of the S2ZE team, focused mainly for the gamemode Zombie Escape but contains useful info for mappers of other gamemodes.
+
+:::note[Our Links]
+Feel free to join our community and follow our work on the following platforms:
+* [Discord](https://discord.gg/s2ze) ([back-up link](https://discord.gg/QsSGf9ZEVs))
+* [Github](https://github.com/Source2ZE)
+* Our ports on the [Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=3070739825)
+:::
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />


### PR DESCRIPTION
Start the implementation of the porting guide into the wiki. Set up the folder structure and add respective titles and descriptions for each section.