### PR TITLE
Correct the Bloom Blur Strength parameter range in the Post Processing Editor effects guide. 

### DIFF
--- a/docs/EngineTools/PostProcessingEditor/effects.mdx
+++ b/docs/EngineTools/PostProcessingEditor/effects.mdx
@@ -732,7 +732,7 @@ Adds bloom/glow around bright areas. Bloom works by extracting pixels above a br
   - **Screen**: Brightens in a softer way than additive (less likely to blow out).
   - **Blur**: More of a hazy/softened effect; can look like general glare.
 
-- **Bloom Strength (0 to 1 for Screen, 0 to 10 for Additive & Blur)**: Overall intensity of the bloom effect.
+- **Bloom Strength (0 to 1 for Screen & Blur, 0 to 10 for Additive )**: Overall intensity of the bloom effect.
 - **Brightness Threshold (0 to 10)**: Minimum brightness required for a pixel to contribute to bloom. Higher values restrict bloom to only the brightest highlights.
 - **Brightness Fade (0 to 10)**: Smooths the threshold edge. Higher values make the transition into bloom softer; lower values make it more sudden.
 - **Skybox Bloom Strength (0 to 1)**: Separate bloom intensity applied to the skybox (since the sky is usually bright, normal bloom settings shouldn’t be applied to it blindly).


### PR DESCRIPTION
Range for the blur strength was written in 0-10 but post-process tool does not allow values on it higher than 1


